### PR TITLE
Only ignore specific lint issue

### DIFF
--- a/demo-android/build.gradle
+++ b/demo-android/build.gradle
@@ -18,7 +18,7 @@ android {
     }
 
     lintOptions {
-        abortOnError false
+        lintConfig file("lint-config.xml")
     }
 
     compileOptions {

--- a/demo-android/lint-config.xml
+++ b/demo-android/lint-config.xml
@@ -1,0 +1,5 @@
+<lint>
+    <issue id="InvalidPackage">
+        <ignore path="**/bcprov-jdk15on-*.jar"/>
+    </issue>
+</lint>


### PR DESCRIPTION
while  f4dd1d1 fixes #13 it is very broadly deactivating lint trowing errors
This PR makes it just ignore the specific lint problem at hand