### PR TITLE
test adding exception info to the RuntimeException in RuntimeException

### DIFF
--- a/lib/src/main/java/im/status/keycard/applet/Mnemonic.java
+++ b/lib/src/main/java/im/status/keycard/applet/Mnemonic.java
@@ -124,7 +124,7 @@ public class Mnemonic {
       PBEKeySpec spec = new PBEKeySpec(mnemonicPhrase.toCharArray(), ("mnemonic" + password).getBytes(), 2048, 512);
       key = skf.generateSecret(spec);
     } catch (Exception e) {
-      throw new RuntimeException("Is Bouncycastle correctly initialized?");
+      throw new RuntimeException("Is Bouncycastle correctly initialized?", e);
     }
 
     return key.getEncoded();


### PR DESCRIPTION
Add information to the RuntimeException so information from the actual Exception is not lost:

Now it looks like this ("Caused by:" added):
```2022-09-09 16:17:33.682 21343-28181/im.status.ethereum.debug E/AndroidRuntime: FATAL EXCEPTION: Thread-39
    Process: im.status.ethereum.debug, PID: 21343
    java.lang.RuntimeException: Is Bouncycastle correctly initialized?
        at im.status.keycard.applet.Mnemonic.toBinarySeed(Mnemonic.java:127)
        at im.status.ethereum.keycard.SmartCard.generateAndLoadKey(SmartCard.java:391)
        at im.status.ethereum.keycard.RNStatusKeycardModule$4.run(RNStatusKeycardModule.java:141)
        at java.lang.Thread.run(Thread.java:1012)
     Caused by: java.lang.IllegalArgumentException: password empty
        at org.bouncycastle.jcajce.provider.symmetric.PBEPBKDF2$BasePBKDF2.engineGenerateSecret(Unknown Source:125)
        at javax.crypto.SecretKeyFactory.generateSecret(SecretKeyFactory.java:518)
        at im.status.keycard.applet.Mnemonic.toBinarySeed(Mnemonic.java:125)
        at im.status.ethereum.keycard.SmartCard.generateAndLoadKey(SmartCard.java:391) 
        at im.status.ethereum.keycard.RNStatusKeycardModule$4.run(RNStatusKeycardModule.java:141) 
        at java.lang.Thread.run(Thread.java:1012) ```
